### PR TITLE
bench: tweak bench param to make it more realistic

### DIFF
--- a/bench/fixtures/index.js
+++ b/bench/fixtures/index.js
@@ -50,7 +50,7 @@ let originalCode = `
   <div {...true ? flex : props.grid } {...grid || ( block ) && $flex } />
   <div {...[, flex, [flex], !flex, -flex, +flex, ~flex, "flex", \`flex\` ] } />
 </div>
-  `.trim().repeat(80)
+  `.trim().repeat(10)
 originalCode = `<>${originalCode}`
 originalCode += '</>'
 

--- a/bench/ms.js
+++ b/bench/ms.js
@@ -14,7 +14,7 @@ function concurrent(n, f) {
 
 await b.suite(
   'unocss concurrent transform jsx',
-  ...fixtures.map(f => b.add(f.name, concurrent(5, f))),
+  ...fixtures.map(f => b.add(f.name, concurrent(8, f))),
   b.cycle(),
   b.complete(),
 )

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
   "scripts": {
     "build": "unbuild",
     "dev": "unbuild --stub",
-    "bench": "node bench/ms.js",
+    "bench": "UV_THREADPOOL_SIZE=8 node bench/ms.js",
     "test": "vitest",
     "release": "bumpp && pnpm publish",
     "prepublishOnly": "pnpm run build"


### PR DESCRIPTION
1. Make file size smaller.
2. Increase libuv threadpool size to take full advantage of CPUs.
3. Slightly make bench leaning toward ast-grep :)